### PR TITLE
Adding logging and refactoring repositories and operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ An opinionated boilerplate for Node web APIs focused on separation of concerns a
   <dt>Logging</dt>
   <dd>
     The <a href="https://www.npmjs.com/package/log4js">Log4js</a> logger is highly pluggable, being able to append the messages to a file during the development and send them to a logging service when on production. Even the requests (through <a href="https://www.npmjs.com/package/morgan">morgan</a>) and queries will be logged.
+    a second Layer of logging called Trace Logging is implemented throu log4js and a memory appender, it serves as an error only file appender meaning that it traces your actions through 
+    operations and if an error is detected, the trace is saved to a file.
   </dd>
 
   <dt>Linter</dt>

--- a/config/environments/development.js
+++ b/config/environments/development.js
@@ -1,14 +1,61 @@
 const path = require('path');
 const logPath = path.join(__dirname, '../../logs/development.log');
+const tracePath = path.join(__dirname, '../../logs/trace.log');
+var config = require('src/infra/logging/MemoryAppender');
 
 module.exports = {
   web: {
-    port: 3000
+    port: 4000
   },
   logging: {
-    appenders: [
-      { type: 'console' },
-      { type: 'file', filename: logPath }
-    ]
-  }
+    appenders: {
+      console :{ type: 'console' },
+      file: { type: 'file', filename: logPath },
+      trace :{
+        type: {
+          configure:config.config()
+        },
+        layout: {
+          type: 'pattern',
+          pattern: '%d %p %c %x{user} %m%n',
+        }
+      },
+      traceFile: {
+        type: 'file',
+        filename: tracePath,
+        layout: {
+          type: 'pattern',
+          pattern: '%m%n',
+        }
+      },
+    },
+    categories: {
+      default:
+        {
+          appenders:
+            [
+              'console',
+              'file',
+
+            ],
+          level: 'debug'
+        },
+      trace: {
+        appenders:
+          [
+            'trace'
+          ],
+        level:'TRACE'
+      },
+      traceFile:{
+        appenders:
+          [
+            'traceFile'
+          ],
+        level:'ALL'
+      }
+
+    }
+  },
+  memoryloggerId:'x-test-req-ID'
 };

--- a/package.json
+++ b/package.json
@@ -38,15 +38,17 @@
     "express": "^4.15.2",
     "express-status-monitor": "^0.1.9",
     "http-status": "^1.0.1",
-    "log4js": "^1.1.1",
+    "log4js": "^5.1.0",
     "method-override": "^2.3.7",
     "morgan": "^1.8.1",
+    "mysql": "^2.17.1",
     "pg": "^6.1.3",
     "pm2": "^2.4.2",
     "sequelize": "^3.30.4",
     "sequelize-cli": "^3.0.0",
     "structure": "^1.2.0",
-    "swagger-ui-express": "^2.0.14"
+    "swagger-ui-express": "^2.0.14",
+    "uuidv4": "^5.0.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/src/app/Operation.js
+++ b/src/app/Operation.js
@@ -2,6 +2,45 @@ const EventEmitter = require('events');
 const define = Object.defineProperty;
 
 class Operation extends EventEmitter {
+
+  constructor(){
+    super();
+    this.steps=0;
+  }
+
+  logToTrace(data){
+    this.container = require('src/container');
+    this.trace = this.container.resolve('Tracelogger');
+    this.trace.trace(data);
+  }
+  logToError(data){
+    this.container = require('src/container');
+    this.trace = this.container.resolve('Tracelogger');
+    this.trace.error(data);
+  }
+
+  logStart(data=undefined){
+
+    this.logToTrace(`starting operation ${this.constructor.name}, with input data ${data?typeof data =='string'?data:JSON.stringify(data):'No Data'}`);
+  }
+
+  logFinish(data=undefined){
+    this.logToTrace(`Ending operation ${this.constructor.name}, with output data : ${data?typeof data =='string'?data:JSON.stringify(data):'No Data'}`);
+  }
+
+  logStep({step, data=undefined}){
+    this.steps++;
+
+
+    this.logToTrace(`Operation ${this.constructor.name} | Step ${this.steps} : ${step} , with data : ${data?typeof data =='string'?data:JSON.stringify(data):'No Data'}`);
+  }
+
+  logError({error=undefined}){
+    this.steps++;
+    this.logToError(`Error after step : ${this.steps} in operation ${this.constructor.name}, with error data : ${error?typeof data =='string'?error:JSON.stringify(error):'No Data'}`);
+  }
+
+
   static setOutputs(outputs) {
     define(this.prototype, 'outputs', {
       value: createOutputs(outputs)
@@ -14,6 +53,10 @@ class Operation extends EventEmitter {
     }
 
     throw new Error(`Invalid output "${output}" to operation ${this.constructor.name}.`);
+  }
+
+  execute(){
+    this.logStart(arguments);
   }
 }
 

--- a/src/app/user/CreateUser.js
+++ b/src/app/user/CreateUser.js
@@ -8,19 +8,26 @@ class CreateUser extends Operation {
   }
 
   async execute(userData) {
+    super.execute();
     const { SUCCESS, ERROR, VALIDATION_ERROR } = this.outputs;
 
     const user = new User(userData);
 
     try {
+      /**
+       * The logStep method is one of multiple predefined logging methods
+       * that create the log trace.
+       * they are used here only for demonstration
+       */
+      this.logStep({step:'adding user to repository', data:userData});
       const newUser = await this.usersRepository.add(user);
-
+      this.logStep({step:'Emitting success event', data:newUser});
       this.emit(SUCCESS, newUser);
     } catch(error) {
       if(error.message === 'ValidationError') {
         return this.emit(VALIDATION_ERROR, error);
       }
-
+      this.logError({error:error});
       this.emit(ERROR, error);
     }
   }

--- a/src/app/user/GetAllUsers.js
+++ b/src/app/user/GetAllUsers.js
@@ -7,6 +7,7 @@ class GetAllUsers extends Operation {
   }
 
   async execute() {
+    super.execute();
     const { SUCCESS, ERROR } = this.outputs;
 
     try {

--- a/src/infra/SequelizeBaseRepository.js
+++ b/src/infra/SequelizeBaseRepository.js
@@ -1,0 +1,187 @@
+
+
+
+
+/**
+ * A superclass for the basic sequelize operations based on models and
+ */
+class SequelizeobjectsRepository {
+  constructor(Model, Mapper) {
+    this.localModel = Model;
+    this.localMapper = Mapper;
+
+  }
+
+  /**
+   * parameters are sequelize query parameters
+   * @param args
+   * will return a promise that resolves an object of the specified model
+   * @returns {Promise<any[]>}
+   */
+  async getAll(...args) {
+    const objects = await this.localModel.findAll(...args);
+
+    return objects.map(this.localMapper.toEntity);
+  }
+
+  /**
+   *
+   * @param id
+   * will return a promise that resolves an object of the specified model
+   * @returns {Promise<*>}
+   */
+  async getById(id) {
+    const object = await this._getById(id);
+
+    return this.localMapper.toEntity(object);
+  }
+
+  /**
+   * parameters are the attribute that should query by and its value
+   * @param attribute
+   * @param value
+   * will return a promise that resolves an object of the specified model
+   * @returns {Promise<*>}
+   */
+  async getByAttribute(attribute, value){
+    const object = await this._getBy(attribute, value);
+
+    return this.localMapper.toEntity(object);
+  }
+
+  /**
+   * will add a new object record to storage
+   * object parameter should be a structure object and should have the
+   * validate method in its prototype. see structure on npmjs.
+   * @param object
+   * will return a promise that resolves an object of the specified model
+   * @returns {Promise<*>}
+   */
+  async add(object) {
+    const { valid, errors } = object.validate();
+
+    if(!valid) {
+      const error = new Error('ValidationError');
+      error.details = errors;
+
+      throw error;
+    }
+
+    const newobject = await this.localModel.create(this.localMapper.toDatabase(object));
+    return this.localMapper.toEntity(newobject);
+  }
+
+  /**
+   * Will remove a record form the storage
+   * @param id
+   * will return a promise that resolves when the action is complete
+   * @returns {Promise<void>}
+   * @throws NotFoundError | any
+   */
+  async remove(id) {
+    const object = await this._getById(id);
+
+    await object.destroy();
+    return;
+  }
+
+  /**
+   *
+   * @param id
+   * @param newData
+   * will return a promise that resolves an object of the specified updated model
+   * @returns {Promise<*>}
+   * @throws NotFoundError | any
+   */
+  async update(id, newData) {
+    const object = await this._getById(id);
+
+    const transaction = await this.localModel.sequelize.transaction();
+
+    try {
+      const updatedobject = await object.update(newData, { transaction });
+      const objectEntity = this.localMapper.toEntity(updatedobject);
+
+      const { valid, errors } = objectEntity.validate();
+
+      if(!valid) {
+        const error = new Error('ValidationError');
+        error.details = errors;
+
+        throw error;
+      }
+
+      await transaction.commit();
+
+      return objectEntity;
+    } catch(error) {
+      await transaction.rollback();
+
+      throw error;
+    }
+  }
+
+  /**
+   * Will count the number of records of the specified model
+   * will return a promise that resolves to a number
+   * @returns {Promise<*>}
+   */
+  async count() {
+    return await this.localModel.count();
+  }
+
+  // Private
+
+  /**
+   * Private internal function
+   * @param id
+   * will return a promise that resolves an object of the specified model
+   * @returns {Promise<Instance>}
+   * @private
+   */
+  async _getById(id) {
+    try {
+      return await this.localModel.findById(id, { rejectOnEmpty: true });
+    } catch(error) {
+      if(error.name === 'SequelizeEmptyResultError') {
+        const notFoundError = new Error('NotFoundError');
+        notFoundError.details = `object with id ${id} can't be found.`;
+
+        throw notFoundError;
+      }
+
+      throw error;
+    }
+  }
+
+
+  /**
+   * Private internal function
+   * @param attribute
+   * @param value
+   * will return a promise that resolves an object of the specified model
+   * @returns {Promise<Instance>}
+   * @private
+   */
+  async _getBy(attribute, value) {
+    try {
+      let options = {};
+      options[attribute]=value;
+      return await this.localModel.findAll({
+        where:options,
+        rejectOnEmpty: true
+      });
+    } catch(error) {
+      if(error.name === 'SequelizeEmptyResultError') {
+        const notFoundError = new Error('NotFoundError');
+        notFoundError.details = `object with attribute ${attribute} and value ${value} can't be found.`;
+
+        throw notFoundError;
+      }
+
+      throw error;
+    }
+  }
+}
+
+module.exports = SequelizeobjectsRepository;

--- a/src/infra/logging/ControllerLogger.js
+++ b/src/infra/logging/ControllerLogger.js
@@ -1,0 +1,79 @@
+
+
+
+
+
+
+module.exports =({appenderBuffer, Tracelogger, config})=>{
+
+  return class ControllerLogger {
+
+    constructor(req, EventEmitterClass, {success, error}={} ){
+      this.appenderBuffer = appenderBuffer;
+      this.TraceLogger = Tracelogger;
+
+
+      if(!success){
+        success='SUCCESS';
+      }
+
+      if(!error){
+        error=['VALIDATION_ERROR', 'ERROR', 'NOT_FOUND'];
+      }
+      if(success instanceof Array){
+        success.map((elem, index)=>{
+          if(EventEmitterClass.outputs[elem]){
+            EventEmitterClass.on(elem, ()=>{
+              if(req.headers[config.memoryloggerId]){
+                this.appenderBuffer.deletemyLog(req.headers[config.memoryloggerId]);
+              }else{
+                this.TraceLogger.toFileLogger.trace('Couldn\'t find a headers ID int he given request');
+              }
+            });
+          }
+        });
+      }else{
+        if(success instanceof String){
+          if(EventEmitterClass.outputs[success]){
+            EventEmitterClass.on(success, ()=>{
+              if(req.headers[config.memoryloggerId]){
+                this.appenderBuffer.deletemyLog(req.headers[config.memoryloggerId]);
+              }else{
+                this.TraceLogger.toFileLogger.trace('Couldn\'t find a headers ID int he given request');
+              }
+            });
+          }
+        }
+      }
+
+      if(error instanceof Array){
+        error.map((elem, index)=>{
+          if(EventEmitterClass.outputs[elem]){
+            EventEmitterClass.on(elem, ()=>{
+              if(req.headers[config.memoryloggerId]){
+                this.TraceLogger.toFileLogger.trace(this.appenderBuffer.gemyLog(req.headers[config.memoryloggerId]));
+              }else{
+                this.TraceLogger.toFileLogger.trace('Couldn\'t find a headers ID int he given request');
+              }
+            });
+          }
+        });
+      }else{
+        if(error instanceof String){
+          if(EventEmitterClass.outputs[error]){
+            EventEmitterClass.on(error, ()=>{
+              if(req.headers[config.memoryloggerId]){
+                this.TraceLogger.toFileLogger.trace(this.appenderBuffer.gemyLog(req.headers[config.memoryloggerId]));
+              }else{
+                this.TraceLogger.toFileLogger.trace('Couldn\'t find a headers ID int he given request');
+              }
+            });
+          }
+
+        }
+      }
+      return EventEmitterClass;
+    }
+  };
+
+};

--- a/src/infra/logging/MemoryAppender.js
+++ b/src/infra/logging/MemoryAppender.js
@@ -1,0 +1,75 @@
+/**
+ * The memory appender is an appender for log4js. it is not found as a dependency
+ * but as an implementation inside our code. it handles Trace logs by saving them in
+ * memory in a variable called Buffermap.
+ * The buffer Map variable holds all the traces for the current running requests
+ * once the request is closed the traces are either deleted, or saved to file and then
+ * deleted form memory, all based on the  outcome fo the request.
+ *
+ * The memory appender follows the log4js memory adapter specification with
+ * a small alteration that lets us access the buffer map variable from memory
+ * as that is not natively supported by log4js specification.
+ */
+
+var oglayouts = undefined;
+var buffer = null;
+var maxBufferSize = null;
+var bufferMap = null;
+
+var options = options || {};
+buffer = options.buffer || [];
+bufferMap = options.bufferMap || {};
+maxBufferSize = options.maxBufferSize || 100;
+
+
+
+module.exports.config = ()=>{
+
+  return (config, layouts, findAppender, levels) => {
+    oglayouts=layouts;
+    var layout = null;
+    if (config.layout) {
+      layout = layouts.layout(config.layout.type, config.layout);
+    }
+    if(config.maxBufferSize){
+      maxBufferSize = config.maxBufferSize;
+    }
+    return memoryAppender(layout, config.timezoneOffset);
+  };
+
+
+};
+
+var memoryAppender = function memoryAppender(layout, timezoneOffset) {
+  layout = layout || oglayouts?oglayouts.basicLayout:undefined;
+  return function(loggingEvent) {
+    if((buffer.length + 1) > maxBufferSize)
+    {
+      var numtoRemove = (buffer.length - maxBufferSize) + 1;
+      if(numtoRemove > 0){ buffer.splice(0, numtoRemove); }
+    }
+    let id = loggingEvent.data[0]?loggingEvent.data[0].id?loggingEvent.data[0].id:'na':'na';
+
+    if(!bufferMap[id]){
+      bufferMap[id]=[];
+    }
+
+    bufferMap[id].push(layout(loggingEvent, timezoneOffset));
+
+  };
+};
+
+
+module.exports.buffer = {
+  bufferMap:bufferMap,
+  deletemyLog:(id)=>{
+    delete bufferMap[id];
+    return true;
+  },
+  gemyLog:(id)=>{
+    return bufferMap[id];
+  }
+
+};
+
+

--- a/src/infra/logging/dataTraceLogger.js
+++ b/src/infra/logging/dataTraceLogger.js
@@ -1,0 +1,42 @@
+const Log4js = require('log4js');
+
+/**
+ *
+ * The dataTraceLogger is a wrapper over the log4js data logging, it injects
+ * a specific Id to identify the log and choose the logger to choose.
+ *
+ * This can be used to inject any kind of data in the logs.
+ */
+
+var TraceData ={
+  user_id:''
+};
+
+
+module.exports = ({ config }) => {
+  Log4js.configure(config.logging);
+
+  let logger  =  Log4js.getLogger('trace');
+  let toFileLogger  =  Log4js.getLogger('traceFile');
+  return {
+    logger:logger,
+    toFileLogger:toFileLogger,
+    trace:(data)=>{
+      logger.trace({
+        id:TraceData.user_id,
+        log:data
+      });
+    },
+    error:(data)=>{
+      logger.error({
+        id:TraceData.user_id,
+        log:data
+      });
+    },
+    setuserID:(id)=>{
+      TraceData.user_id=id;
+      console.log(TraceData);
+    },
+    traceStaticData:TraceData
+  };
+};

--- a/src/infra/user/SequelizeUsersRepository.js
+++ b/src/infra/user/SequelizeUsersRepository.js
@@ -1,90 +1,10 @@
 const UserMapper = require('./SequelizeUserMapper');
+const BaseSequelizeRepository = require('../SequelizeBaseRepository');
 
-class SequelizeUsersRepository {
+class SequelizeUsersRepository extends BaseSequelizeRepository{
   constructor({ UserModel }) {
-    this.UserModel = UserModel;
-  }
+    super(UserModel,UserMapper);
 
-  async getAll(...args) {
-    const users = await this.UserModel.findAll(...args);
-
-    return users.map(UserMapper.toEntity);
-  }
-
-  async getById(id) {
-    const user = await this._getById(id);
-
-    return UserMapper.toEntity(user);
-  }
-
-  async add(user) {
-    const { valid, errors } = user.validate();
-
-    if(!valid) {
-      const error = new Error('ValidationError');
-      error.details = errors;
-
-      throw error;
-    }
-
-    const newUser = await this.UserModel.create(UserMapper.toDatabase(user));
-    return UserMapper.toEntity(newUser);
-  }
-
-  async remove(id) {
-    const user = await this._getById(id);
-
-    await user.destroy();
-    return;
-  }
-
-  async update(id, newData) {
-    const user = await this._getById(id);
-
-    const transaction = await this.UserModel.sequelize.transaction();
-
-    try {
-      const updatedUser = await user.update(newData, { transaction });
-      const userEntity = UserMapper.toEntity(updatedUser);
-
-      const { valid, errors } = userEntity.validate();
-
-      if(!valid) {
-        const error = new Error('ValidationError');
-        error.details = errors;
-
-        throw error;
-      }
-
-      await transaction.commit();
-
-      return userEntity;
-    } catch(error) {
-      await transaction.rollback();
-
-      throw error;
-    }
-  }
-
-  async count() {
-    return await this.UserModel.count();
-  }
-
-  // Private
-
-  async _getById(id) {
-    try {
-      return await this.UserModel.findById(id, { rejectOnEmpty: true });
-    } catch(error) {
-      if(error.name === 'SequelizeEmptyResultError') {
-        const notFoundError = new Error('NotFoundError');
-        notFoundError.details = `User with id ${id} can't be found.`;
-
-        throw notFoundError;
-      }
-
-      throw error;
-    }
   }
 }
 

--- a/src/interfaces/http/MiddleWare/LogIdInjectorMiddleware.js
+++ b/src/interfaces/http/MiddleWare/LogIdInjectorMiddleware.js
@@ -1,0 +1,17 @@
+const uuidv4 = require('uuid/v4');
+
+/**
+ * This will inject a request Id for every request and use that to store the trace related
+ * to that request. using this id, the trace can then be identified and either stored
+ * in case of error or deleted in case of success.
+ * @param config
+ * @param Tracelogger
+ * @returns {Function}
+ */
+module.exports=({config, Tracelogger})=>{
+  return  (req, res, next)=>{
+    req.headers[config.memoryloggerId] = uuidv4();
+    Tracelogger.setuserID(req.headers[config.memoryloggerId]);
+    next();
+  };
+};

--- a/src/interfaces/http/router.js
+++ b/src/interfaces/http/router.js
@@ -5,8 +5,9 @@ const bodyParser = require('body-parser');
 const compression = require('compression');
 const methodOverride = require('method-override');
 const controller = require('./utils/createControllerRoutes');
+const { inject } = require('awilix-express');
 
-module.exports = ({ config, containerMiddleware, loggerMiddleware, errorHandler, swaggerMiddleware }) => {
+module.exports = ({ config, loggerIdInjectorMiddleware, containerMiddleware, loggerMiddleware, errorHandler, swaggerMiddleware }) => {
   const router = Router();
 
   /* istanbul ignore if */
@@ -27,6 +28,8 @@ module.exports = ({ config, containerMiddleware, loggerMiddleware, errorHandler,
     .use(bodyParser.json())
     .use(compression())
     .use(containerMiddleware)
+    .use(inject('ControllerLogger'))
+    .use(loggerIdInjectorMiddleware)
     .use('/docs', swaggerMiddleware);
 
   /*

--- a/src/interfaces/http/user/UsersController.js
+++ b/src/interfaces/http/user/UsersController.js
@@ -1,14 +1,21 @@
 const { Router } = require('express');
 const { inject } = require('awilix-express');
 const Status = require('http-status');
-
+const loggerInjector = require('../utils/ControllerLoggerWrapper');
 const UsersController = {
   get router() {
     const router = Router();
 
     router.use(inject('userSerializer'));
 
-    router.get('/', inject('getAllUsers'), this.index);
+    /**
+     * In the next injection the loggerInjector is a wrapper over the
+     * awilix inject method. what is does is still to inject the the operation
+     * using the inject method from awilix and then add the log handling by using
+     * the ControllerLogger module. see infra/logging/ControllerLogger.js.
+     * for demonstration it is only used in the first route.
+     */
+    router.get('/', loggerInjector('getAllUsers'), this.index);
     router.get('/:id', inject('getUser'), this.show);
     router.post('/', inject('createUser'), this.create);
     router.put('/:id', inject('updateUser'), this.update);

--- a/src/interfaces/http/utils/ControllerLoggerWrapper.js
+++ b/src/interfaces/http/utils/ControllerLoggerWrapper.js
@@ -1,0 +1,16 @@
+const { inject } = require('awilix-express');
+
+/**
+ * The controller logger wrapper is used to inject an operation (module)
+ * and inject into the operation the loggingController to listen to success and error events
+ * and respectively delete temporary trace or store in file.
+ * @param module
+ * @returns {*[]}
+ */
+module.exports=(module)=>{
+  console.log(module);
+  return [inject(module), (req, res, next)=>{
+    req[module]= new req.ControllerLogger(req, req[module]);
+    next();
+  }];
+};


### PR DESCRIPTION
I added logging capabilities based on operations. 
logging in the operation means adding steps and their description. this can be done via predefined methods that take a description and extra data. the logs are stored to file on error only and are marked by a request ID that is injected. on a success, the trace id deleted forever.

added refactoring for the operations (logging methods) and the repositories.
create a base repository for sequelize with the most common methods predefined. extending the base repository and injecting the sequelize model in the super constructor as well as the mapper is a mandatory step. 

this only allows for one model and one mapper. 

Changed readme to include logging mechanism description.