### PR TITLE
Extract REPL impl. to lib

### DIFF
--- a/src/_boot/repl.ts
+++ b/src/_boot/repl.ts
@@ -1,18 +1,10 @@
 import { makeModule } from '@/context';
-import { EnvironmentConfig } from '@/_lib/Environment';
-import { makeNodeREPL } from '@/_lib/repl';
+import { makeREPL, REPLConfigType } from '@/_lib/repl';
 
-type REPLConfig = {
-  appName: string;
-  cli: boolean;
-  repl: {
-    port: number;
-  };
-  environment: EnvironmentConfig['environment'];
-};
+type REPLConfig = REPLConfigType<{ appName: string; cli: boolean; repl: { port: number } }>;
 
 const repl = makeModule('repl', async ({ app: { onReady, terminate }, container, config, logger }) => {
-  const repl = makeNodeREPL({ container, config, logger });
+  const repl = makeREPL({ container, config, logger });
 
   onReady(async () => {
     await repl.start({ terminate });

--- a/src/_lib/repl/index.ts
+++ b/src/_lib/repl/index.ts
@@ -3,11 +3,20 @@ import vm from 'vm';
 import { createServer, Server } from 'net';
 import { AwilixContainer } from 'awilix';
 import { Logger } from 'pino';
-import { REPLConfig } from '@/_boot/repl';
+import { EnvironmentConfig } from '../Environment';
+
+type REPLConfigType<T> = {
+  [key in keyof T]: T[key];
+};
 
 type ReplParameters = {
   container: AwilixContainer;
-  config: REPLConfig;
+  config: REPLConfigType<{
+    appName: string;
+    cli: boolean;
+    repl: { port: number };
+    environment: EnvironmentConfig['environment'];
+  }>;
   logger: Logger;
 };
 
@@ -29,7 +38,7 @@ const promisableEval: REPLEval = (cmd, context, filename, callback) => {
   return callback(null, result);
 };
 
-const makeNodeREPL = ({
+const makeREPL = ({
   container,
   config: {
     appName,
@@ -94,4 +103,5 @@ const makeNodeREPL = ({
   };
 };
 
-export { makeNodeREPL };
+export { makeREPL };
+export type { REPLConfigType };


### PR DESCRIPTION
### Description 

As of current REPL implementation live inside the integrations of boot processes, this PR abstracts REPL module to be implemented under `_lib`.

### Related issues
Addresses issue #91 