### PR TITLE
add tsconfig.prod.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.prod.json",
     "dev": "tsnd --transpile-only --files src/index.ts | pino-pretty -c -l",
     "debug": "tsnd --transpile-only --inspect --files src/index.ts | pino-pretty -c -l",
     "cli": "tsnd --transpile-only --files src/index.ts --cli",

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "src/__tests__",
+    "src/**/__tests__"
+  ]
+}


### PR DESCRIPTION
# Description

I just added tsconfig.prod.json to make more easy to manage the files that you want to go to ./dist, and i removed the tests from this even because when I ran the build and then the tests it ended up running both the dist and src tests

# Why

The main reason to do this is because the production build does not need to have tests